### PR TITLE
feat: Add css prop

### DIFF
--- a/packages/react/src/styled/styled.tsx
+++ b/packages/react/src/styled/styled.tsx
@@ -14,6 +14,13 @@ import React, {
     FC, ReactElement, useEffect, useRef,
 } from 'react';
 
+type StyledCSS<
+    T extends NiftyTheme,
+    B extends Breakpoints,
+    P extends NiftyProps> = {
+        css?: StyleProvider<T, B, P>
+    };
+
 const createStyled = <
     T extends NiftyTheme,
     B extends Breakpoints = typeof DEFAULT_BREAKPOINTS,
@@ -32,9 +39,17 @@ const createStyled = <
         tag: HTMLTag,
         styleProvider: StyleProvider<T, B, P>,
         ...classProvider: ClassProvider
-    ): FC<P & AllHTMLAttributes<HTMLElement>> => (props: P): ReactElement => {
-        const className = cssWithProps(styleProvider, ...classProvider)(props);
+    ): FC<P & AllHTMLAttributes<HTMLElement> & StyledCSS<T, B, P>> => (
+        props: P & StyledCSS<T, B, P>,
+    ): ReactElement => {
+        let className = cssWithProps(styleProvider, ...classProvider)(props);
         const rendered = useRef(false);
+
+        const { css: cssProp } = props;
+
+        if (cssProp) {
+            className += ` ${cssWithProps(cssProp)(props)}`;
+        }
 
         useEffect(() => {
             if (rendered.current) {

--- a/site/docs/features/styling.md
+++ b/site/docs/features/styling.md
@@ -72,6 +72,16 @@ const Button = styled('button', {
 <Button>Hello</Button>
 ```
 
+You can also define additional styles at the component-level with the `css` prop, to override or add styles on a per-component basis. You will get the same auto-completion:
+
+```tsx
+<Button>Hello</Button>
+// Change the background for this button only
+<Button css={{
+    background: 'blue',
+}}>Hello</Button>
+```
+
 Any `props` passed to the style component will be transmitted to the generated React component:
 
 ```tsx


### PR DESCRIPTION
Add a `css` prop to `styled` component, to override or define new styles at the component-level.

- [x] `css` prop
- [x] Update documentation